### PR TITLE
refactor(package): add es5 module build config

### DIFF
--- a/config/grunt/aliases.js
+++ b/config/grunt/aliases.js
@@ -2,7 +2,8 @@ module.exports = {
     build: [
         'clean:build',
         'sh:build-es2018',
-        'sh:build-es5'
+        'sh:build-es5-bundle',
+        'sh:build-es5-module'
     ],
     continuous: [
         'karma:continuous'

--- a/config/grunt/sh.js
+++ b/config/grunt/sh.js
@@ -5,8 +5,11 @@ module.exports = (grunt) => {
         'build-es2018': {
             cmd: 'tsc -p src/tsconfig.json'
         },
-        'build-es5': {
+        'build-es5-bundle': {
             cmd: 'rollup -c config/rollup/bundle.js'
+        },
+        'build-es5-module': {
+            cmd: 'rollup -c config/rollup/module.js'
         },
         'lint-config': {
             cmd: `eslint --config config/eslint/config.json ${ (fix) ? '--fix ' : '' }--report-unused-disable-directives *.js config/**/*.js`

--- a/config/rollup/module.js
+++ b/config/rollup/module.js
@@ -1,0 +1,28 @@
+import babel from 'rollup-plugin-babel';
+
+export default { // eslint-disable-line import/no-default-export
+    input: 'build/es2018/module.js',
+    output: {
+        file: 'build/es5/module.js',
+        format: 'esm',
+        name: 'workerTimersBroker'
+    },
+    plugins: [
+        babel({
+            exclude: 'node_modules/**',
+            plugins: [
+                '@babel/plugin-external-helpers',
+                '@babel/plugin-transform-runtime'
+            ],
+            presets: [
+                [
+                    '@babel/preset-env',
+                    {
+                        modules: false
+                    }
+                ]
+            ],
+            runtimeHelpers: true
+        })
+    ]
+};

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "license": "MIT",
   "main": "build/es5/bundle.js",
-  "module": "build/es2018/module.js",
+  "module": "build/es5/module.js",
   "name": "worker-timers-broker",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds the `browser` field to `package.json` to prioritize the es5 build when using webpack with `web` target.

See related webpack issue: https://github.com/webpack/webpack/issues/5756